### PR TITLE
Refactor configure.ac to move INCLUDE_INTERFACE logic to Autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,35 +50,8 @@ else
     fi
 fi
 
-AC_MSG_CHECKING([is IRIX platform])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-    #ifdef __sgi
-    /* IRIX Macro from github:cpredef/predef/OperatingSystems.md#L314 */
-    #else
-    #error Not IRIX Platform
-    #endif
-]])], [
-    enable_interface=no
-    AC_MSG_RESULT([yes])
-    AC_MSG_NOTICE([Interactive interface is not supported on IRIX])
-], [
-    enable_interface=yes
-    AC_MSG_RESULT([no])
-])
-AC_MSG_CHECKING([is BSDI platform])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-    #ifdef __bsdi__
-    /* BSDI Macro from github:cpredef/predef/OperatingSystems.md#L103 */
-    #else
-    #error Not BSDI Platform
-    #endif
-]])], [
-    enable_interface=no
-    AC_MSG_RESULT([yes])
-    AC_MSG_NOTICE([Interactive interface is not supported on BSDI])
-], [
-    AC_MSG_RESULT([no])
-])
+# Interface support checking
+enable_interface=yes
 
 dnl Check Shared Memory support
 AC_CHECK_FUNCS(shmget)

--- a/configure.ac
+++ b/configure.ac
@@ -37,16 +37,16 @@ if test $ac_cv_sizeof_unsigned_short_int -ne 2; then
     AC_MSG_ERROR([unsigned short is NOT 2 bytes... quiting])
 fi
 
-AC_CHECK_SIZEOF(unsigned long int)
-if test $ac_cv_sizeof_unsigned_long_int -eq 4; then
-AC_DEFINE(USE_32_LONG_INT, 1, [none])
+AC_CHECK_SIZEOF(unsigned int)
+if test $ac_cv_sizeof_unsigned_int -eq 4; then
+    AC_DEFINE(USE_32_INT, 1, [Use unsigned int for 32-bit type])
 else
-    echo "unsigned long is NOT 4 bytes... hmmm..."
-    AC_CHECK_SIZEOF(unsigned int)
-    if test $ac_cv_sizeof_unsigned_int -ne 4; then
-        AC_MSG_ERROR([unsigned int is NOT 4 bytes either... quiting])
+    echo "Unsigned int is NOT 4 bytes... checking unsigned long?..."
+    AC_CHECK_SIZEOF(unsigned long int)
+    if test $ac_cv_sizeof_unsigned_long_int -ne 4; then
+        AC_MSG_ERROR([Unsigned long is not 4 bytes either... quitting])
     else
-        AC_DEFINE(USE_32_INT, 1, [none])
+        AC_DEFINE(USE_32_LONG_INT, 1, [Use unsigned long int for 32-bit type])
     fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -12,20 +12,9 @@ AC_CONFIG_HEADERS([config.h])
 # Checks for programs.
 AC_PROG_CC
 
-# Checks for libraries.
-# FIXME: sniffit links with libncurses when it is available, even if it does
-# not use it because src/sn_config.h does not define INCLUDE_INTERFACE because
-# other conditions are not met.  It would be better to move that logic entirely
-# to Autoconf and to define (or not) INCLUDE_INTERFACE only here.
-AC_CHECK_LIB(ncurses, initscr)
-AC_CHECK_LIB(pcap, pcap_open_live, , [AC_MSG_ERROR([Couldn't find libpcap])])
-
-# Checks for header files.
-AC_CHECK_HEADERS([ncurses.h])
+# Checks for pcap.
+AC_CHECK_LIB([pcap], [pcap_open_live], [], [AC_MSG_ERROR([Couldn't find libpcap])])
 AC_CHECK_HEADERS([pcap.h], , AC_MSG_ERROR([pcap.h not found]))
-
-dnl Check Shared Memory support
-AC_CHECK_FUNCS(shmget)
 
 dnl exit function check
 AC_CHECK_FUNCS(atexit)
@@ -59,6 +48,66 @@ else
     else
         AC_DEFINE(USE_32_INT, 1, [none])
     fi
+fi
+
+AC_MSG_CHECKING([is IRIX platform])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    #ifdef __sgi
+    /* IRIX Macro from github:cpredef/predef/OperatingSystems.md#L314 */
+    #else
+    #error Not IRIX Platform
+    #endif
+]])], [
+    enable_interface=no
+    AC_MSG_RESULT([yes])
+    AC_MSG_NOTICE([Interactive interface is not supported on IRIX])
+], [
+    enable_interface=yes
+    AC_MSG_RESULT([no])
+])
+AC_MSG_CHECKING([is BSDI platform])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    #ifdef __bsdi__
+    /* BSDI Macro from github:cpredef/predef/OperatingSystems.md#L103 */
+    #else
+    #error Not BSDI Platform
+    #endif
+]])], [
+    enable_interface=no
+    AC_MSG_RESULT([yes])
+    AC_MSG_NOTICE([Interactive interface is not supported on BSDI])
+], [
+    AC_MSG_RESULT([no])
+])
+
+dnl Check Shared Memory support
+AC_CHECK_FUNCS(shmget)
+if test "$ac_cv_func_shmget" != yes; then
+    enable_interface=no
+    AC_MSG_NOTICE([The interactive interface requires shared memory functionality])
+fi
+
+dnl Find ncurses.h and link ncurses only if all other checks pass
+if test "$enable_interface" = yes; then
+    # Checks for ncurses
+    AC_CHECK_HEADERS([ncurses.h], [
+        dnl Have header so we can now check for ncurses library
+        AC_CHECK_LIB([ncurses], [initscr], [], [
+            enable_interface=no
+            AC_MSG_NOTICE([The interactive interface requires ncurses library])
+        ])
+    ], [
+        enable_interface=no
+        AC_MSG_NOTICE([The interactive interface requires ncurses.h header])
+    ])
+fi
+
+dnl Define INCLUDE_INTERFACE or not
+if test "$enable_interface" = yes; then
+    AC_DEFINE(INCLUDE_INTERFACE, 1, [Define to 1 to enable interactive interface])
+    AC_MSG_NOTICE([Interactive interface: Enabled])
+else
+    AC_MSG_NOTICE([Interactive interface: Disabled])
 fi
 
 AC_CONFIG_FILES([Makefile src/Makefile])

--- a/src/sn_config.h
+++ b/src/sn_config.h
@@ -6,25 +6,7 @@
 
 #include <config.h>
 
-#define INCLUDE_INTERFACE            /* By default */
-
-#ifndef HAVE_SHMGET                                 /* No Shared memory  */
-#undef INCLUDE_INTERFACE
-#endif
-#ifndef HAVE_LIBNCURSES                             /* ncurses not found */
-#undef INCLUDE_INTERFACE
-#endif
-#ifndef HAVE_NCURSES_H                              /* ncurses not found */
-#undef INCLUDE_INTERFACE
-#endif
-#ifdef IRIX                                      /* No interface on IRIX */
-#undef INCLUDE_INTERFACE
-#endif
-
-/* Not supported yet */
-#ifdef BSDI
-#undef INCLUDE_INTERFACE
-#endif
+/* Definition of INCLUDE_INTERFACE is now handled in config.h by Autoconf  */
 
 #ifdef HAVE_ATEXIT
 #define exit_func(x)    atexit(x)


### PR DESCRIPTION
Reworked the configure scripts to not link ncurses if the other checks fail, and ensure we don't try and build with the interactive interface if we don't have ncurses.